### PR TITLE
Fix issue #15

### DIFF
--- a/src/parameditwidget.cpp
+++ b/src/parameditwidget.cpp
@@ -52,6 +52,13 @@ void ParamEditWidget::composeWidgets() {
 
 void ParamEditWidget::connectWidgets() {
   QObject::connect(
+    m_fieldWidget, &QLineEdit::textEdited,
+    this, [this](const QString &text) {
+      m_fieldWidget->setText(QString(text).replace(",", "."));
+    }
+  );
+
+  QObject::connect(
     m_fieldWidget, &QLineEdit::editingFinished,
     this, [this]() {
       emit valueChanged(m_fieldWidget->text().toDouble());


### PR DESCRIPTION
Add rule to ParamEditWidget's QLineEdit which replace all entered commas with dot ('.').